### PR TITLE
Protecting chrome error parsing from crashes.

### DIFF
--- a/src/stackParser.js
+++ b/src/stackParser.js
@@ -53,12 +53,12 @@ var root = window.root;
             }
         },
 
-        parseV8OrIE: function ErrorStackParser$$parseV8OrIE(error) {
+          parseV8OrIE: function ErrorStackParser$$parseV8OrIE(error) {
         	var level =0;
             return error.stack.split('\n').slice(1).map(function (line) {
                 var tokens = line.replace(/^\s+/, '').split(/\s+/).slice(1);
-                var locationParts = this.extractLocation(tokens.pop().replace(/[\(\)\s]/g, ''));
-                var functionName = (!tokens[0] || tokens[0] === 'Anonymous') ? undefined : tokens[0];
+                var locationParts = tokens[0] !== undefined ? this.extractLocation(tokens.pop().replace(/[\(\)\s]/g, '')) : ['unknown','unknown','unknown'];
+                var functionName = (!tokens[0] || tokens[0] === 'Anonymous') ? 'unknown' : tokens[0];
                 return new StackFrame(functionName, undefined, locationParts[0], locationParts[1], locationParts[2], level++);
             }, this);
         },

--- a/test/stackParser-tests.js
+++ b/test/stackParser-tests.js
@@ -59,7 +59,7 @@ describe('ErrorStackParser', function () {
             expect(stackFrames[0]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 13, 17]);
             expect(stackFrames[1]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 16, 5]);
             expect(stackFrames[2]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 20, 5]);
-            expect(stackFrames[3]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 24, 4]);
+            expect(stackFrames[3]).toMatchStackFrame(['unknown', undefined, 'http://path/to/file.js', 24, 4]);
         });
 
         it('should parse V8 entries with no location', function () {
@@ -79,7 +79,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.IE_10);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 48, 13]);
+            expect(stackFrames[0]).toMatchStackFrame(['unknown', undefined, 'http://path/to/file.js', 48, 13]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 46, 9]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 82, 1]);
         });
@@ -88,7 +88,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.IE_11);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 47, 21]);
+            expect(stackFrames[0]).toMatchStackFrame(['unknown', undefined, 'http://path/to/file.js', 47, 21]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 45, 13]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 108, 1]);
         });
@@ -129,7 +129,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.OPERA_25);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 47, 22]);
+            expect(stackFrames[0]).toMatchStackFrame(['unknown', undefined, 'http://path/to/file.js', 47, 22]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 52, 15]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 108, 168]);
         });


### PR DESCRIPTION
This is an initial fix to prevent the unhandled exception that can occur in some processing of angular errors in chrome. Defaults to safe values of 'unknown' until some improvements can be done to the token logic.