### PR TITLE
copy any existing properties over to work with angular mocks

### DIFF
--- a/src/LogInterceptor.ts
+++ b/src/LogInterceptor.ts
@@ -58,14 +58,21 @@
         }
 
         delegator(orignalFn, level) {
-            return function() {
+     
+            var interceptingFn = function () {
                 var args = [].slice.call(arguments);
                 // track the call
                 LogInterceptor.interceptFuntion(args[0], level);
                 // Call the original 
                 orignalFn.apply(null, args);
             };
+            
+            for(var n in orignalFn){
+            
+                interceptingFn[n] = orignalFn[n];
+            }
+            
+            return interceptingFn;
         }
-
 
     }


### PR DESCRIPTION
We have had trouble using ng-mock when this module has decorated the $log it looses the additional properties in the mocked object

This copies all properties over to the intercepting function