### PR TITLE
Track View Load Durations

### DIFF
--- a/src/ApplicationInsights.ts
+++ b/src/ApplicationInsights.ts
@@ -175,6 +175,20 @@ class ApplicationInsights {
         return validateProperties;
     }
 
+    private validateDuration(duration) {
+
+        if (Tools.isNullOrUndefined(duration)) {
+            return null;
+        }
+
+        if (!Tools.isNumber(duration) || duration < 0) {
+            this._log.warn("The value of the durations parameter must be a positive number");
+            return null;
+        }
+
+        return duration;
+    }
+
     private validateSeverityLevel(level) {
         // https://github.com/Microsoft/ApplicationInsights-JS/blob/7bbf8b7a3b4e3610cefb31e9d61765a2897dcb3b/JavaScript/JavaScriptSDK/Contracts/Generated/SeverityLevel.ts
         /*
@@ -230,7 +244,7 @@ class ApplicationInsights {
         }
     }
 
-    trackPageView(pageName?, pageUrl?, properties?, measurements?) {
+    trackPageView(pageName?, pageUrl?, properties?, measurements?, duration?: number) {
         // TODO: consider possible overloads (no name or url but properties and measurements)
         const data = this.generateAppInsightsData(ApplicationInsights.names.pageViews,
             ApplicationInsights.types.pageViews,
@@ -239,7 +253,8 @@ class ApplicationInsights {
                 url: Tools.isNullOrUndefined(pageUrl) ? this._location.absUrl() : pageUrl,
                 name: Tools.isNullOrUndefined(pageName) ? this._location.path() : pageName,
                 properties: this.validateProperties(properties),
-                measurements: this.validateMeasurements(measurements)
+                measurements: this.validateMeasurements(measurements),
+                duration: this.validateDuration(duration)
             });
         this.sendData(data);
     }

--- a/src/angularModule.ts
+++ b/src/angularModule.ts
@@ -38,7 +38,9 @@ angularAppInsights.run([
 
         $rootScope.$on("$viewContentLoaded", (e, view) => {
 
-            if (applicationInsightsService.options.autoPageViewTracking) {
+            if (applicationInsightsService.options.autoPageViewTracking
+                    && locationChangeStartOn) {
+
                 var duration = (new Date()).getTime() - locationChangeStartOn;
                 var name = applicationInsightsService.options.applicationName + $location.path();
 

--- a/src/angularModule.ts
+++ b/src/angularModule.ts
@@ -25,16 +25,32 @@ angularAppInsights.provider("applicationInsightsService", () => new AppInsightsP
 
 // the run block sets up automatic page view tracking
 angularAppInsights.run([
-    "$rootScope", "$location", "applicationInsightsService", ($rootScope, $location, applicationInsightsService: ApplicationInsights) => {
-        $rootScope.$on("$locationChangeSuccess", () => {
+    "$rootScope", "$location", "applicationInsightsService",
+    ($rootScope, $location, applicationInsightsService: ApplicationInsights) => {
+        var locationChangeStartOn: number;
+
+        $rootScope.$on("$locationChangeStart", () => {
 
             if (applicationInsightsService.options.autoPageViewTracking) {
-                applicationInsightsService.trackPageView(applicationInsightsService.options.applicationName + $location.path());
+                locationChangeStartOn = (new Date()).getTime();
+            }
+        });
+
+        $rootScope.$on("$viewContentLoaded", (e, view) => {
+
+            if (applicationInsightsService.options.autoPageViewTracking) {
+                var duration = (new Date()).getTime() - locationChangeStartOn;
+                var name = applicationInsightsService.options.applicationName + $location.path();
+
+                if (view) {
+                    name += "#" + view;
+                }
+
+                applicationInsightsService.trackPageView(name, null, null, null, duration);
             }
         });
     }
 ]);
-
 
 class AppInsightsProvider implements angular.IServiceProvider {
     // configuration properties for the provider

--- a/test/appInsights-tests.js
+++ b/test/appInsights-tests.js
@@ -75,7 +75,7 @@ describe('Application Insights for Angular JS Provider', function(){
 				expect(data.data.item.url).toEqual('http://www.somewhere.com/sometest/page');
 				expect(data.data.item.properties.testprop).toEqual('testvalue');
 				expect(data.data.item.measurements.metric1).toEqual(2345);
-
+				expect(data.data.item.duration).toEqual(3456);
 
 				return true;
 			}, function(headers){
@@ -85,7 +85,7 @@ describe('Application Insights for Angular JS Provider', function(){
 			.respond(200,'');
 
 
-			_insights.trackPageView('/sometest/page','http://www.somewhere.com/sometest/page',{testprop:'testvalue'},{metric1:2345});
+			_insights.trackPageView('/sometest/page','http://www.somewhere.com/sometest/page',{testprop:'testvalue'},{metric1:2345}, 3456);
 			$httpBackend.flush();
  
 		});

--- a/test/appInsights-tests.js
+++ b/test/appInsights-tests.js
@@ -34,7 +34,7 @@ describe('Application Insights for Angular JS Provider', function(){
 
 	}));
 
-	beforeEach(inject(function (applicationInsightsService, $injector,$http) {
+	beforeEach(inject(function (applicationInsightsService,$injector,$http) {
 	    _insights = applicationInsightsService;
 	    $httpBackend = $injector.get('$httpBackend');
 	    $log = $injector.get('$log');
@@ -60,7 +60,11 @@ describe('Application Insights for Angular JS Provider', function(){
     	});
 	});
 
-	describe('Page view Tracking', function(){
+	describe('Page view Tracking', function() {
+
+	  beforeEach(inject(function(applicationInsightsService) {
+  	    applicationInsightsService.options.autoPageViewTracking = true;
+	  }));
 
 		it('Sent data should match expectications',function(){
 
@@ -89,6 +93,27 @@ describe('Application Insights for Angular JS Provider', function(){
 			$httpBackend.flush();
  
 		});
+
+	  it('Tracking sent on $locationChangeStart+$ViewContentLoad', inject(function($rootScope) {
+
+	      var viewName = 'VIEW_NAME';
+
+	      $httpBackend.resetExpectations();
+	      $httpBackend.expect('POST', 'https://dc.services.visualstudio.com/v2/track', function(json) {
+	          var data = JSON.parse(json);
+	          
+	          expect(data.data.item.name).toEqual('angularjs-appinsights-unittests#VIEW_NAME');
+
+	          return true;
+	        })
+	      .respond(200, '');
+
+	      $rootScope.$broadcast('$locationChangeStart');
+	      $rootScope.$broadcast('$viewContentLoaded', viewName);
+
+	      $httpBackend.flush();
+
+	    }));
 	});
 
 	describe('Log Message Tracking', function(){


### PR DESCRIPTION
Hi there

We need to be able to track duration of view load times

When a $locationChangeStart happens the timer is started
Then for each $viewContentLoaded event a call is made with the duration for that view to be loaded

What do you think? Ant