### PR TITLE
Handling "Unhandled" Error message formats.

### DIFF
--- a/dist/angular-applicationinsights.js
+++ b/dist/angular-applicationinsights.js
@@ -852,9 +852,9 @@ var ApplicationInsights = (function () {
             handledAt: "Unhandled",
             exceptions: [
                 {
-                    typeName: exception.name,
-                    message: exception.message,
-                    stack: exception.stack,
+                    typeName: exception.name || "Unhandled",
+                    message: exception.message || "Unhandled",
+                    stack: exception.stack || "Unhandled",
                     parsedStack: parsedStack,
                     hasFullStack: !Tools.isNullOrUndefined(parsedStack)
                 }


### PR DESCRIPTION
Currently if we have any non formatted error message such as without having exception.name , exception.message , exception.stack. We are not tracking the error message instead we end up throwing exception for the track message.

So, changed the code in  a way that if any unhandled error message ( un-formatted ) we are handling in a app inshights code block.